### PR TITLE
[Devcontainer] Replace by ruff and add JupyterLab

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,6 +5,8 @@
 	"image": "mcr.microsoft.com/devcontainers/base:ubuntu",
 	"features": {
 		"ghcr.io/devcontainers/features/python:1": {
+			// Uncomment if you want to run JupyterLab
+			// "installJupyterlab": true,
 			"version": "latest"
 		},
 		//"ghcr.io/devcontainers/features/anaconda:1": {},
@@ -30,16 +32,28 @@
 
 	"postCreateCommand": "pip install cookiecutter-data-science",
 
+	// Uncomment if you want to run JupyterLab
+	// "postStartCommand": "jupyter lab --ip=0.0.0.0 --port=4321",
+	
+	// Uncomment if you want to run JupyterLab
+	// "appPort": [
+	// 	4321
+	// ],
+
 	// Configure tool-specific properties.
 	"customizations": {
 		"vscode": {
 			"settings": {
 				"[python]": {
-					"defaultInterpreterPath": "/opt/conda/bin/python",
-					"editor.defaultFormatter": "ms-python.black-formatter",
+					"defaultInterpreterPath": "/usr/local/python",
+					"editor.defaultFormatter": "charliermarsh.ruff",
 					"editor.formatOnType": true,
-					"editor.formatOnSave": true
+					"editor.formatOnSave": true,
+					"editor.codeActionsOnSave": {
+					  "source.organizeImports": "explicit"
+					}
 				},
+				"notebook.formatOnSave.enabled": true,
 				"[jupyter]": {
 					"themeMatplotlibPlots": true,
 					"widgetScriptSources": [
@@ -67,7 +81,7 @@
 			"extensions": [
 				"ms-toolsai.datawrangler",
 				"ms-toolsai.vscode-jupyter-cell-tags",
-				"ms-python.black-formatter",
+				"charliermarsh.ruff",
 				"ms-toolsai.jupyter",
 				"ms-python.python",
 				"reditorsupport.r"

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ cd my-project
 code .
 ```
 
+> If you want to use JupyterLab, you must uncomment the installation, execution on container start and appPort in .devcontainer/devcontainer.json.
+
 You should reopen VSCode in a devcontainer.
 
 Then give the rights to your user to the files that will be overwritten:


### PR DESCRIPTION
* Replacing formatting and linting by Ruff
* Adding as comment a way to add JupyterLab easily
* Fix python path based on default path from the python devcontainer feature